### PR TITLE
Fix ILF patch with wrong variable name

### DIFF
--- a/docker-setup/ilf/go/src/ilf.patch
+++ b/docker-setup/ilf/go/src/ilf.patch
@@ -155,7 +155,7 @@ index e02cef2..985de32 100644
                  try:
                      _, value_from_block = logger.trace_log_stack(i-1, -2)
                      if value_from_block:
-+                        if blockstate_op == TIMESTAMP:
++                        if block_state_op == TIMESTAMP:
 +                            if log.pc not in self.tds:
 +                                elapsed = time.time() - self.start_time
 +                                self.dump_bug(elapsed, 'BlockstateDependency', 0, logger.tx.method)

--- a/docker-setup/ilf/go/src/ilf.patch
+++ b/docker-setup/ilf/go/src/ilf.patch
@@ -121,7 +121,7 @@ index e02cef2..985de32 100644
                  try:
                      _, value_from_block = logger.trace_log_stack(i-1, -1)
                      if value_from_block:
-+                        if blockstate_op == TIMESTAMP:
++                        if block_state_op == TIMESTAMP:
 +                            if log.pc not in self.tds:
 +                                elapsed = time.time() - self.start_time
 +                                self.dump_bug(elapsed, 'BlockstateDependency', 0, logger.tx.method)
@@ -138,7 +138,7 @@ index e02cef2..985de32 100644
                  try:
                      _, value_from_block = logger.trace_log_stack(i-1, -3)
                      if value_from_block:
-+                        if blockstate_op == TIMESTAMP:
++                        if block_state_op == TIMESTAMP:
 +                            if log.pc not in self.tds:
 +                                elapsed = time.time() - self.start_time
 +                                self.dump_bug(elapsed, 'BlockstateDependency', 0, logger.tx.method)


### PR DESCRIPTION
`blockstate_op` was the wrong name for the variable `block_state_op`. I had some errors for ILF while replicating the artifact, and when I looked in the file `stdout.txt` I got a bunch of `NameError`. Note: this variable was created by the Smartian patch. 

```
0x96edbe868531bd23a6c05e9d0c424ea64fb1b78b/stdout.txt:NameError: name 'blockstate_op' is not defined
0xbe4041d55db380c5ae9d4a9b9703f1ed4e7e3888/stdout.txt:NameError: name 'blockstate_op' is not defined
etheraffle/stdout.txt:NameError: name 'blockstate_op' is not defined
etherstore/stdout.txt:NameError: name 'blockstate_op' is not defined
lucky_doubler/stdout.txt:NameError: name 'blockstate_op' is not defined

```

This might change the graphics and tables in the main Smartian paper, but I'm not sure what is the exactly impact. 
